### PR TITLE
Implement basic precompiles for BW6-761

### DIFF
--- a/common/ecprecompile.go
+++ b/common/ecprecompile.go
@@ -1,5 +1,26 @@
+// Package common
+//
+// We need these as constants, but in a type that doesn't support easy constant initialization, so we have them here
+// as functions.
+
 package common
 
-func ECPrecompileHelloContractAddress() Address {
-	return BytesToAddress([]byte{byte(0x8a)})
+func ECPrecompileBW6761G1AddContractAddress() Address {
+	return BytesToAddress([]byte{byte(0x80)})
+}
+
+func ECPrecompileBW6761G1ScalarMulContractAddress() Address {
+	return BytesToAddress([]byte{byte(0x81)})
+}
+
+func ECPrecompileBW6761G2AddContractAddress() Address {
+	return BytesToAddress([]byte{byte(0x82)})
+}
+
+func ECPrecompileBW6761G2ScalarMulContractAddress() Address {
+	return BytesToAddress([]byte{byte(0x83)})
+}
+
+func ECPrecompileBW6761PairingCheckContractAddress() Address {
+	return BytesToAddress([]byte{byte(0x84)})
 }

--- a/core/vm/contracts_ec.go
+++ b/core/vm/contracts_ec.go
@@ -17,8 +17,23 @@
 package vm
 
 import (
+	"errors"
+	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fp"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+)
+
+var (
+	errBW6InvalidFieldElementLength = errors.New("invalid field element length")
+	errBW6InvalidInputLength        = errors.New("invalid input length")
+)
+
+var (
+	sizeOfFieldElement = 96
+	sizeOfAffinePoint  = 2 * sizeOfFieldElement
+	sizeOfEVMWordBytes = 32
 )
 
 // ECPrecompiledContract is an interface for precompiled contracts to do with extended elliptic curve operations. The
@@ -31,7 +46,11 @@ type ECPrecompiledContract interface {
 // ECPrecompiledContracts is the default set of pre-compiled contracts that implement extended support for elliptic
 // curves.
 var ECPrecompiledContracts = map[common.Address]ECPrecompiledContract{
-	common.ECPrecompileHelloContractAddress(): &helloPrecompile{},
+	common.ECPrecompileBW6761G1AddContractAddress():        &bw6761G1AddPrecompile{},
+	common.ECPrecompileBW6761G1ScalarMulContractAddress():  &bw6761G1ScalarMulPrecompile{},
+	common.ECPrecompileBW6761G2AddContractAddress():        &bw6761G2AddPrecompile{},
+	common.ECPrecompileBW6761G2ScalarMulContractAddress():  &bw6761G2ScalarMulPrecompile{},
+	common.ECPrecompileBW6761PairingCheckContractAddress(): &bw6761PairingCheckPrecompile{},
 }
 
 // RunECPrecompiledContract executes and evaluates the output of an elliptic curve precompiled contract.
@@ -53,16 +72,354 @@ func RunECPrecompiledContract(evm *EVM, precompile ECPrecompiledContract, input 
 	return output, suppliedGas, err
 }
 
-// helloPrecompile is a basic test precompile that does nothing of interest.
-type helloPrecompile struct{}
+// bw6761G1AddPrecompile implements the addition of G1 affine points where each coordinate is a 3-word field element.
+//
+// The input is assumed to encode all numbers in normal form using big-endian byte order. Operand encoding is as
+// follows:
+//
+// - 96 bytes of x_1 coordinate for the first point
+// - 96 bytes of y_1 coordinate for the first point
+// - 96 bytes of x_2 coordinate for the second point
+// - 96 bytes of y_2 coordinate for the second point
+//
+// It returns a G1 affine point consisting of 96 bytes for the x coordinate, and 96 bytes for the y coordinate. Both
+// elements are encoded in big-endian byte ordering and normal form.
+type bw6761G1AddPrecompile struct{}
 
-func (c *helloPrecompile) RequiredGas(_ []byte) uint64 {
-	return 0
+func (*bw6761G1AddPrecompile) RequiredGas(input []byte) uint64 {
+	return params.Bw6761G1AddGas
 }
 
-func (c *helloPrecompile) Run(evm *EVM, _ []byte) ([]byte, error) {
-	log.Debug("Executing the hello precompile")
-	log.Warn("Hello Precompile")
+func (*bw6761G1AddPrecompile) Run(evm *EVM, input []byte) ([]byte, error) {
+	// Input contains four 96-byte numbers in normal form and using big-endian byte encoding.
+	if len(input) != 2*sizeOfAffinePoint {
+		return nil, errBW6InvalidInputLength
+	}
 
-	return nil, nil
+	// After decoding, point1 is a G1 point with its elements in Montgomery form
+	point1, err1 := decodeG1Point(input[:sizeOfAffinePoint])
+	if err1 != nil {
+		return nil, err1
+	}
+
+	// After decoding, point2 is a G1 point with its elements in Montgomery form
+	point2, err2 := decodeG1Point(input[sizeOfAffinePoint:])
+	if err2 != nil {
+		return nil, err2
+	}
+
+	// Perform the actual math over the Jacobian as it's faster. FromAffine expects the G1Affine point to have elements
+	// in Montgomery form.
+	point1Jac := bw6761.G1Jac{}
+	point1Jac.FromAffine(point1)
+	point2Jac := bw6761.G1Jac{}
+	point2Jac.FromAffine(point2)
+
+	// Expects all elements in Montgomery form, which they are
+	sumPointJac := point1Jac.AddAssign(&point2Jac)
+
+	// This conversion also expects elements in Montgomery form, which they are
+	sumPoint := bw6761.G1Affine{}
+	sumPoint.FromJacobian(sumPointJac)
+
+	// Encode back into bytes, which expects the field elements of the point in Montgomery form, but the result is in
+	// normal form using big-endian byte ordering.
+	enc := encodeG1Point(&sumPoint)
+
+	return enc, nil
+}
+
+// bw6761G2AddPrecompile implements the addition of G2 affine points where each coordinate is a 3-word field element.
+//
+// Operand encoding is as follows:
+//
+// - 96 bytes of x_1 coordinate for the first point
+// - 96 bytes of y_1 coordinate for the first point
+// - 96 bytes of x_2 coordinate for the second point
+// - 96 bytes of y_2 coordinate for the second point
+//
+// It returns a G2 affine point consisting of 3 words for the x coordinate, and 3 words for the y coordinate.
+type bw6761G2AddPrecompile struct{}
+
+func (*bw6761G2AddPrecompile) RequiredGas(input []byte) uint64 {
+	return params.Bw6761G2AddGas
+}
+
+func (*bw6761G2AddPrecompile) Run(evm *EVM, input []byte) ([]byte, error) {
+	// Input contains four 96-byte numbers in normal form and using big-endian byte encoding.
+	if len(input) != 2*sizeOfAffinePoint {
+		return nil, errBW6InvalidInputLength
+	}
+
+	// After decoding, point1 is a G2 point with its elements in Montgomery form
+	point1, err1 := decodeG2Point(input[:sizeOfAffinePoint])
+	if err1 != nil {
+		return nil, err1
+	}
+
+	// After decoding, point2 is a G2 point with its elements in Montgomery form
+	point2, err2 := decodeG2Point(input[sizeOfAffinePoint:])
+	if err2 != nil {
+		return nil, err2
+	}
+
+	// Perform the actual math over the Jacobian as it's faster. FromAffine expects the G1Affine point to have elements
+	// in Montgomery form.
+	point1Jac := bw6761.G2Jac{}
+	point1Jac.FromAffine(point1)
+	point2Jac := bw6761.G2Jac{}
+	point2Jac.FromAffine(point2)
+
+	// Expects all elements in Montgomery form, which they are
+	sumPointJac := point1Jac.AddAssign(&point2Jac)
+
+	// This conversion also expects elements in Montgomery form, which they are
+	sumPoint := bw6761.G2Affine{}
+	sumPoint.FromJacobian(sumPointJac)
+
+	// Encode back into bytes, which expects the field elements of the point in Montgomery form, but the result is in
+	// normal form using big-endian byte ordering.
+	enc := encodeG2Point(&sumPoint)
+
+	return enc, nil
+}
+
+// bw6761G1ScalarMulPrecompile implements multiplication of a G1 affine point where each coordinate is a 3-word field
+// element by a scalar value. The scalar value is expected to be an EVM word using big-endian encoding.
+//
+// Operand encoding is as follows:
+//
+// - 96 bytes of x coordinate for the point
+// - 96 bytes of y coordinate for the point
+// - 32 bytes of the scalar to multiply the point by.
+//
+// It returns a G1 affine point consisting of 3 words for the x coordinate, and 3 words for the y coordinate.
+type bw6761G1ScalarMulPrecompile struct{}
+
+func (*bw6761G1ScalarMulPrecompile) RequiredGas(input []byte) uint64 {
+	return params.Bw6761G1MulGas
+}
+
+func (*bw6761G1ScalarMulPrecompile) Run(evm *EVM, input []byte) ([]byte, error) {
+	// Input contains two 96-byte numbers in normal form and using big-endian byte encoding, followed by a single 32
+	// byte number in normal form using big-endian encoding
+	if len(input) != sizeOfAffinePoint+sizeOfEVMWordBytes {
+		return nil, errBW6InvalidInputLength
+	}
+
+	// After decoding, point is a G1 point with its elements in Montgomery form
+	point, err1 := decodeG1Point(input[:sizeOfAffinePoint])
+	if err1 != nil {
+		return nil, err1
+	}
+
+	// After decoding, scalar is a big int in normal form
+	scalar := big.NewInt(0).SetBytes(input[sizeOfAffinePoint:])
+
+	// Now we can perform the multiplication, leaving point again as a G1 point in Montgomery form
+	point.ScalarMultiplication(point, scalar)
+
+	// And we can return the result
+	return encodeG1Point(point), nil
+}
+
+// bw6761G2ScalarMulPrecompile implements multiplication of a G2 affine point where each coordinate is a 3-word field
+// element by a scalar value. The scalar value is expected to be a word.
+//
+// Operand encoding is as follows:
+//
+// - 96 bytes of x coordinate for the point
+// - 96 bytes of y coordinate for the point
+// - 32 bytes of the scalar to multiply the point by.
+//
+// It returns a G2 affine point consisting of 3 words for the x coordinate, and 3 words for the y coordinate.
+type bw6761G2ScalarMulPrecompile struct{}
+
+func (*bw6761G2ScalarMulPrecompile) RequiredGas(input []byte) uint64 {
+	return params.Bw6761G2MulGas
+}
+
+func (*bw6761G2ScalarMulPrecompile) Run(evm *EVM, input []byte) ([]byte, error) {
+	// Input contains two 96-byte numbers in normal form and using big-endian byte encoding, followed by a single 32
+	// byte number in normal form using big-endian encoding
+	if len(input) != sizeOfAffinePoint+sizeOfEVMWordBytes {
+		return nil, errBW6InvalidInputLength
+	}
+
+	// After decoding, point is a G1 point with its elements in Montgomery form
+	point, err1 := decodeG2Point(input[:sizeOfAffinePoint])
+	if err1 != nil {
+		return nil, err1
+	}
+
+	// After decoding, scalar is a big int in normal form
+	scalar := big.NewInt(0).SetBytes(input[sizeOfAffinePoint:])
+
+	// Now we can perform the multiplication, leaving point again as a G1 point in Montgomery form
+	point.ScalarMultiplication(point, scalar)
+
+	// And we can return the result
+	return encodeG2Point(point), nil
+}
+
+// bw6761PairingCheckPrecompile implements the pairing check operation on two G1 affine points where each coordinate is
+// a 3-word field element.
+//
+// Operand encoding is as follows:
+//
+// - 96 bytes of x_1 coordinate for the first point
+// - 96 bytes of y_1 coordinate for the first point
+// - 96 bytes of x_2 coordinate for the second point
+// - 96 bytes of y_2 coordinate for the second point
+//
+// The result is 1 if the pairing is correct, and 0 otherwise, encoded in 1 byte.
+type bw6761PairingCheckPrecompile struct{}
+
+func (*bw6761PairingCheckPrecompile) RequiredGas(input []byte) uint64 {
+	return params.Bw6761PairingGas
+}
+
+func (*bw6761PairingCheckPrecompile) Run(evm *EVM, input []byte) ([]byte, error) {
+	// Input contains four 96-byte numbers in normal form and using big-endian byte encoding
+	if len(input) != sizeOfAffinePoint*2 {
+		return nil, errBW6InvalidInputLength
+	}
+
+	// After decoding, point1 is a G1 point with its elements in Montgomery form
+	point1, err1 := decodeG1Point(input[:sizeOfAffinePoint])
+	if err1 != nil {
+		return nil, err1
+	}
+
+	// After decoding, point2 is a G2 point with its elements in Montgomery form
+	point2, err2 := decodeG2Point(input[sizeOfAffinePoint:])
+	if err2 != nil {
+		return nil, err2
+	}
+
+	// Our data is in the right format, so we can now just compute the pairing
+	result, err := bw6761.PairingCheck([]bw6761.G1Affine{*point1}, []bw6761.G2Affine{*point2})
+	if err != nil {
+		return nil, err
+	}
+
+	var wordResult byte
+	if result {
+		wordResult = 1
+	} else {
+		wordResult = 0
+	}
+
+	return []byte{wordResult}, nil
+}
+
+// decodeG1Point decodes a BW6 G1 Affine point from a byte array.
+//
+// It assumes that it is passed 192 bytes with the first 96 as the X coordinate and the second 96 as the Y coordinate.
+// It assumes that these coordinates are in non-Montgomery form and are using big-endian encoding.
+//
+// It returns the G1 affine point from the bytes, with both elements in Montgomery form.
+func decodeG1Point(input []byte) (*bw6761.G1Affine, error) {
+	if len(input) != sizeOfAffinePoint {
+		return nil, errBW6InvalidInputLength
+	}
+
+	var err error
+	point := bw6761.G1Affine{}
+
+	// Input is in normal big-endian, output is in Montgomery
+	err = decodeFieldElementInto(input[:sizeOfFieldElement], &point.X)
+	if err != nil {
+		return nil, err
+	}
+
+	// Input is in normal big-endian, output is in Montgomery
+	err = decodeFieldElementInto(input[sizeOfFieldElement:], &point.Y)
+	if err != nil {
+		return nil, err
+	}
+
+	return &point, nil
+}
+
+// decodeG2Point decodes a BW6 G2 Affine point from a byte array.
+//
+// It assumes that it is passed 192 bytes with the first 96 as the X coordinate and the second 96 as the Y coordinate.
+// It assumes that these coordinates are in non-Montgomery form and are using big-endian encoding.
+//
+// It returns the G2 affine point from the bytes, with both elements in Montgomery form.
+func decodeG2Point(input []byte) (*bw6761.G2Affine, error) {
+	if len(input) != sizeOfAffinePoint {
+		return nil, errBW6InvalidInputLength
+	}
+
+	var err error
+	point := bw6761.G2Affine{}
+
+	// Input is in normal big-endian, output is in Montgomery
+	err = decodeFieldElementInto(input[:sizeOfFieldElement], &point.X)
+	if err != nil {
+		return nil, err
+	}
+
+	// Input is in normal big-endian, output is in Montgomery
+	err = decodeFieldElementInto(input[sizeOfFieldElement:], &point.Y)
+	if err != nil {
+		return nil, err
+	}
+
+	return &point, nil
+}
+
+// encodeG1Point encodes a BW6 G1 affine point into a byte array.
+//
+// It assumes that the length of the byte array is 192 bytes. The X coordinate is in the first 96 bytes, and the Y
+// coordinate is in the second 96 bytes. It assumes that the X and Y field elements in the input are in Montgomery form.
+//
+// The numbers encoded in the returned byte array are provided in normal form and using big-endian byte encoding.
+func encodeG1Point(input *bw6761.G1Affine) []byte {
+	output := make([]byte, sizeOfAffinePoint)
+
+	// Bytes gets it in non-Montgomery, big-endian form, so we're good here.
+	xBytes := input.X.Bytes()
+	yBytes := input.Y.Bytes()
+	copy(output[:sizeOfFieldElement], xBytes[:])
+	copy(output[sizeOfFieldElement:], yBytes[:])
+
+	return output
+}
+
+// encodeG2Point encodes a BW6 G2 affine point into a byte array.
+//
+// It assumes that the length of the byte array is 192 bytes. The X coordinate is in the first 96 bytes, and the Y
+// coordinate is in the second 96 bytes. It assumes that the X and Y field elements in the input are in Montgomery form.
+//
+// The numbers encoded in the returned byte array are provided in normal form and using big-endian byte encoding.
+func encodeG2Point(input *bw6761.G2Affine) []byte {
+	output := make([]byte, sizeOfAffinePoint)
+
+	// Bytes gets it in non-Montgomery, big-endian form, so we're good here.
+	xBytes := input.X.Bytes()
+	yBytes := input.Y.Bytes()
+	copy(output[:sizeOfFieldElement], xBytes[:])
+	copy(output[sizeOfFieldElement:], yBytes[:])
+
+	return output
+}
+
+// decodeFieldElementInto decodes the input as a single field element, assuming that the input it is in big-endian
+// encoding.
+//
+// The target `element` for the decoding contains the field element in Montgomery form when this call returns.
+func decodeFieldElementInto(input []byte, element *fp.Element) error {
+	// Input is big-endian and not Montgomery form
+	if len(input) != sizeOfFieldElement {
+		return errBW6InvalidFieldElementLength
+	}
+
+	// SetBytes interprets the input as the bytes of a BE unsigned integer, and sets element to the Montgomery form of
+	// that integer.
+	element.SetBytes(input)
+
+	return nil
 }

--- a/core/vm/contracts_ec_test.go
+++ b/core/vm/contracts_ec_test.go
@@ -1,35 +1,421 @@
 package vm
 
 import (
+	bw6761 "github.com/consensys/gnark-crypto/ecc/bw6-761"
+	"github.com/consensys/gnark-crypto/ecc/bw6-761/fp"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"math/big"
 	"testing"
 )
 
-// TestHelloPrecompile_Run ensures that it is possible to run the basic precompile directly.
-func TestHelloPrecompile_Run(t *testing.T) {
+func TestBw6761G1AddPrecompile_RequiredGas(t *testing.T) {
+	input := make([]byte, 0)
+	requiredGas := (&bw6761G1AddPrecompile{}).RequiredGas(input)
+	require.Equal(t, requiredGas, params.Bw6761G1AddGas)
+}
+
+func TestBw6761G1AddPrecompile_Run(t *testing.T) {
 	// Set up the test controller and make sure it runs cleanup
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
 	// Build our test transaction
-	helloTx := types.NewTransaction(0, common.ECPrecompileHelloContractAddress(), nil, 0, nil, []byte{})
-	require.EqualValues(t, *helloTx.To(), common.ECPrecompileHelloContractAddress())
+	g1AddTx := types.NewTransaction(0, common.ECPrecompileBW6761G1AddContractAddress(), nil, 0, nil, []byte{})
+	require.Equal(t, *g1AddTx.To(), common.ECPrecompileBW6761G1AddContractAddress())
 
 	// Set up the EVM state
 	publicState := NewMockStateDB(controller)
 	depth := 1
 	evm := &EVM{
 		depth:        depth,
-		currentTx:    helloTx,
+		currentTx:    g1AddTx,
 		publicState:  publicState,
 		privateState: publicState,
 	}
 
-	// Run the code
-	retData, err := (&helloPrecompile{}).Run(evm, []byte{})
-	require.Nil(t, retData)
+	// Set up the inputs. They need to be in Montgomery form as Bytes converts back into normal form.
+	var x1, y1, x2, y2 fp.Element
+	_, _ = x1.SetRandom()
+	_, _ = y1.SetRandom()
+	_, _ = x2.SetRandom()
+	_, _ = y2.SetRandom()
+	x1Bytes := x1.Bytes()
+	y1Bytes := y1.Bytes()
+	x2Bytes := x2.Bytes()
+	y2Bytes := y2.Bytes()
+
+	point1Bytes := make([]byte, sizeOfAffinePoint)
+	copy(point1Bytes[:sizeOfFieldElement], x1Bytes[:])
+	copy(point1Bytes[sizeOfFieldElement:], y1Bytes[:])
+	point1, err1 := decodeG1Point(point1Bytes)
+	require.NoErrorf(t, err1, "")
+	point2Bytes := make([]byte, sizeOfAffinePoint)
+	copy(point2Bytes[:sizeOfFieldElement], x2Bytes[:])
+	copy(point2Bytes[sizeOfFieldElement:], y2Bytes[:])
+	point2, err2 := decodeG1Point(point2Bytes)
+	require.NoErrorf(t, err2, "")
+	inputBytes := make([]byte, 2*sizeOfAffinePoint)
+	copy(inputBytes[:sizeOfFieldElement], x1Bytes[:])
+	copy(inputBytes[sizeOfFieldElement:sizeOfFieldElement*2], y1Bytes[:])
+	copy(inputBytes[sizeOfFieldElement*2:sizeOfFieldElement*3], x2Bytes[:])
+	copy(inputBytes[sizeOfFieldElement*3:], y2Bytes[:])
+
+	// Create the expected output. They also need to be in Montgomery form as Bytes converts back into normal form.
+	point1Jac := bw6761.G1Jac{}
+	point1Jac.FromAffine(point1)
+	point2Jac := bw6761.G1Jac{}
+	point2Jac.FromAffine(point2)
+	resultJac := point1Jac.AddAssign(&point2Jac)
+	resultAffine := bw6761.G1Affine{}
+	resultAffine.FromJacobian(resultJac)
+	resultXBytes := resultAffine.X.Bytes()
+	resultYBytes := resultAffine.Y.Bytes()
+	expectedBytes := make([]byte, sizeOfAffinePoint)
+	copy(expectedBytes[:sizeOfFieldElement], resultXBytes[:])
+	copy(expectedBytes[sizeOfFieldElement:], resultYBytes[:])
+
+	// Run the precompile
+	retData, err := (&bw6761G1AddPrecompile{}).Run(evm, inputBytes)
 	require.Nil(t, err)
+
+	// Check the returned value is correct
+	require.Equal(t, len(retData), len(expectedBytes))
+	require.Equal(t, retData, expectedBytes)
+}
+
+func TestBw6761G2AddPrecompile_RequiredGas(t *testing.T) {
+	input := make([]byte, 0)
+	requiredGas := (&bw6761G2AddPrecompile{}).RequiredGas(input)
+	require.Equal(t, requiredGas, params.Bw6761G2AddGas)
+}
+
+func TestBw6761G2AddPrecompile_Run(t *testing.T) {
+	// Set up the test controller and make sure it runs cleanup
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	// Build our test transaction
+	g1AddTx := types.NewTransaction(0, common.ECPrecompileBW6761G2AddContractAddress(), nil, 0, nil, []byte{})
+	require.Equal(t, *g1AddTx.To(), common.ECPrecompileBW6761G2AddContractAddress())
+
+	// Set up the EVM state
+	publicState := NewMockStateDB(controller)
+	depth := 1
+	evm := &EVM{
+		depth:        depth,
+		currentTx:    g1AddTx,
+		publicState:  publicState,
+		privateState: publicState,
+	}
+
+	// Set up the inputs. They need to be in Montgomery form as Bytes converts back into normal form.
+	var x1, y1, x2, y2 fp.Element
+	_, _ = x1.SetRandom()
+	_, _ = y1.SetRandom()
+	_, _ = x2.SetRandom()
+	_, _ = y2.SetRandom()
+	x1Bytes := x1.Bytes()
+	y1Bytes := y1.Bytes()
+	x2Bytes := x2.Bytes()
+	y2Bytes := y2.Bytes()
+
+	point1Bytes := make([]byte, sizeOfAffinePoint)
+	copy(point1Bytes[:sizeOfFieldElement], x1Bytes[:])
+	copy(point1Bytes[sizeOfFieldElement:], y1Bytes[:])
+	point1, err1 := decodeG2Point(point1Bytes)
+	require.NoErrorf(t, err1, "")
+	point2Bytes := make([]byte, sizeOfAffinePoint)
+	copy(point2Bytes[:sizeOfFieldElement], x2Bytes[:])
+	copy(point2Bytes[sizeOfFieldElement:], y2Bytes[:])
+	point2, err2 := decodeG2Point(point2Bytes)
+	require.NoErrorf(t, err2, "")
+	inputBytes := make([]byte, 2*sizeOfAffinePoint)
+	copy(inputBytes[:sizeOfFieldElement], x1Bytes[:])
+	copy(inputBytes[sizeOfFieldElement:sizeOfFieldElement*2], y1Bytes[:])
+	copy(inputBytes[sizeOfFieldElement*2:sizeOfFieldElement*3], x2Bytes[:])
+	copy(inputBytes[sizeOfFieldElement*3:], y2Bytes[:])
+
+	// Create the expected output. They also need to be in Montgomery form as Bytes converts back into normal form.
+	point1Jac := bw6761.G2Jac{}
+	point1Jac.FromAffine(point1)
+	point2Jac := bw6761.G2Jac{}
+	point2Jac.FromAffine(point2)
+	resultJac := point1Jac.AddAssign(&point2Jac)
+	resultAffine := bw6761.G2Affine{}
+	resultAffine.FromJacobian(resultJac)
+	resultXBytes := resultAffine.X.Bytes()
+	resultYBytes := resultAffine.Y.Bytes()
+	expectedBytes := make([]byte, sizeOfAffinePoint)
+	copy(expectedBytes[:sizeOfFieldElement], resultXBytes[:])
+	copy(expectedBytes[sizeOfFieldElement:], resultYBytes[:])
+
+	// Run the precompile
+	retData, err := (&bw6761G2AddPrecompile{}).Run(evm, inputBytes)
+	require.Nil(t, err)
+
+	// Check the returned value is correct
+	require.Equal(t, len(retData), len(expectedBytes))
+	require.Equal(t, retData, expectedBytes)
+}
+
+func TestBw6761G1ScalarMulPrecompile_RequiredGas(t *testing.T) {
+	input := make([]byte, 0)
+	requiredGas := (&bw6761G1ScalarMulPrecompile{}).RequiredGas(input)
+	require.Equal(t, requiredGas, params.Bw6761G1MulGas)
+}
+
+func TestBw6761G1ScalarMulPrecompile_Run(t *testing.T) {
+	// Set up the test controller and make sure it runs cleanup
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	// Build our test transaction
+	g1AddTx := types.NewTransaction(0, common.ECPrecompileBW6761G1ScalarMulContractAddress(), nil, 0, nil, []byte{})
+	require.Equal(t, *g1AddTx.To(), common.ECPrecompileBW6761G1ScalarMulContractAddress())
+
+	// Set up the EVM state
+	publicState := NewMockStateDB(controller)
+	depth := 1
+	evm := &EVM{
+		depth:        depth,
+		currentTx:    g1AddTx,
+		publicState:  publicState,
+		privateState: publicState,
+	}
+
+	// Set up the inputs. They need to be in Montgomery form as Bytes converts back into normal form.
+	var x, y fp.Element
+	_, _ = x.SetRandom()
+	_, _ = y.SetRandom()
+	xBytes := x.Bytes()
+	yBytes := y.Bytes()
+
+	pointBytes := make([]byte, sizeOfAffinePoint)
+	copy(pointBytes[:sizeOfFieldElement], xBytes[:])
+	copy(pointBytes[sizeOfFieldElement:], yBytes[:])
+	point, err1 := decodeG1Point(pointBytes)
+	require.NoErrorf(t, err1, "")
+
+	scalar := new(big.Int)
+	scalar.Exp(big.NewInt(2), big.NewInt(256), nil).Sub(scalar, big.NewInt(1))
+
+	inputBytes := make([]byte, sizeOfAffinePoint+sizeOfEVMWordBytes)
+	copy(inputBytes[:sizeOfFieldElement], xBytes[:])
+	copy(inputBytes[sizeOfFieldElement:sizeOfFieldElement*2], yBytes[:])
+	copy(inputBytes[sizeOfFieldElement*2:], scalar.Bytes())
+
+	// Create the expected output. They also need to be in Montgomery form as Bytes converts back into normal form.
+	expectedResult := point.ScalarMultiplication(point, scalar)
+	expectedXBytes := expectedResult.X.Bytes()
+	expectedYBytes := expectedResult.Y.Bytes()
+	expectedBytes := make([]byte, sizeOfAffinePoint)
+	copy(expectedBytes[:sizeOfFieldElement], expectedXBytes[:])
+	copy(expectedBytes[sizeOfFieldElement:], expectedYBytes[:])
+
+	// Run the precompile
+	retData, err := (&bw6761G1ScalarMulPrecompile{}).Run(evm, inputBytes)
+	require.Nil(t, err)
+
+	// Check the returned value is correct
+	require.Equal(t, len(retData), len(expectedBytes))
+	require.Equal(t, retData, expectedBytes)
+}
+
+func TestBw6761G2ScalarMulPrecompile_RequiredGas(t *testing.T) {
+	input := make([]byte, 0)
+	requiredGas := (&bw6761G2ScalarMulPrecompile{}).RequiredGas(input)
+	require.Equal(t, requiredGas, params.Bw6761G2MulGas)
+}
+
+func TestBw6761G2ScalarMulPrecompile_Run(t *testing.T) {
+	// Set up the test controller and make sure it runs cleanup
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	// Build our test transaction
+	g1AddTx := types.NewTransaction(0, common.ECPrecompileBW6761G2ScalarMulContractAddress(), nil, 0, nil, []byte{})
+	require.Equal(t, *g1AddTx.To(), common.ECPrecompileBW6761G2ScalarMulContractAddress())
+
+	// Set up the EVM state
+	publicState := NewMockStateDB(controller)
+	depth := 1
+	evm := &EVM{
+		depth:        depth,
+		currentTx:    g1AddTx,
+		publicState:  publicState,
+		privateState: publicState,
+	}
+
+	// Set up the inputs. They need to be in Montgomery form as Bytes converts back into normal form.
+	var x, y fp.Element
+	_, _ = x.SetRandom()
+	_, _ = y.SetRandom()
+	xBytes := x.Bytes()
+	yBytes := y.Bytes()
+
+	pointBytes := make([]byte, sizeOfAffinePoint)
+	copy(pointBytes[:sizeOfFieldElement], xBytes[:])
+	copy(pointBytes[sizeOfFieldElement:], yBytes[:])
+	point, err1 := decodeG2Point(pointBytes)
+	require.NoErrorf(t, err1, "")
+
+	scalar := new(big.Int)
+	scalar.Exp(big.NewInt(2), big.NewInt(256), nil).Sub(scalar, big.NewInt(1))
+
+	inputBytes := make([]byte, sizeOfAffinePoint+sizeOfEVMWordBytes)
+	copy(inputBytes[:sizeOfFieldElement], xBytes[:])
+	copy(inputBytes[sizeOfFieldElement:sizeOfFieldElement*2], yBytes[:])
+	copy(inputBytes[sizeOfFieldElement*2:], scalar.Bytes())
+
+	// Create the expected output. They also need to be in Montgomery form as Bytes converts back into normal form.
+	expectedResult := point.ScalarMultiplication(point, scalar)
+	expectedXBytes := expectedResult.X.Bytes()
+	expectedYBytes := expectedResult.Y.Bytes()
+	expectedBytes := make([]byte, sizeOfAffinePoint)
+	copy(expectedBytes[:sizeOfFieldElement], expectedXBytes[:])
+	copy(expectedBytes[sizeOfFieldElement:], expectedYBytes[:])
+
+	// Run the precompile
+	retData, err := (&bw6761G2ScalarMulPrecompile{}).Run(evm, inputBytes)
+	require.Nil(t, err)
+
+	// Check the returned value is correct
+	require.Equal(t, len(retData), len(expectedBytes))
+	require.Equal(t, retData, expectedBytes)
+}
+
+func TestBw6761PairingCheckPrecompile_RequiredGas(t *testing.T) {
+	input := make([]byte, 0)
+	requiredGas := (&bw6761PairingCheckPrecompile{}).RequiredGas(input)
+	require.Equal(t, requiredGas, params.Bw6761PairingGas)
+}
+
+func TestBw6761PairingCheckPrecompile_Run(t *testing.T) {
+	// Set up the test controller and make sure it runs cleanup
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	// Build our test transaction
+	g1AddTx := types.NewTransaction(0, common.ECPrecompileBW6761PairingCheckContractAddress(), nil, 0, nil, []byte{})
+	require.Equal(t, *g1AddTx.To(), common.ECPrecompileBW6761PairingCheckContractAddress())
+
+	// Set up the EVM state
+	publicState := NewMockStateDB(controller)
+	depth := 1
+	evm := &EVM{
+		depth:        depth,
+		currentTx:    g1AddTx,
+		publicState:  publicState,
+		privateState: publicState,
+	}
+
+	// Set up the inputs. They need to be in Montgomery form as Bytes converts back into normal form.
+	var g1Gen bw6761.G1Jac
+	g1Gen.X.SetString("6238772257594679368032145693622812838779005809760824733138787810501188623461307351759238099287535516224314149266511977132140828635950940021790489507611754366317801811090811367945064510304504157188661901055903167026722666149426237")
+	g1Gen.Y.SetString("2101735126520897423911504562215834951148127555913367997162789335052900271653517958562461315794228241561913734371411178226936527683203879553093934185950470971848972085321797958124416462268292467002957525517188485984766314758624099")
+	g1Gen.Z.SetOne()
+
+	var g2Gen bw6761.G2Jac
+	g2Gen.X.SetString("6445332910596979336035888152774071626898886139774101364933948236926875073754470830732273879639675437155036544153105017729592600560631678554299562762294743927912429096636156401171909259073181112518725201388196280039960074422214428")
+	g2Gen.Y.SetString("562923658089539719386922163444547387757586534741080263946953401595155211934630598999300396317104182598044793758153214972605680357108252243146746187917218885078195819486220416605630144001533548163105316661692978285266378674355041")
+	g2Gen.Z.SetOne()
+
+	g1GenAff := bw6761.G1Affine{}
+	g1GenAff.FromJacobian(&g1Gen)
+
+	g2GenAff := bw6761.G2Affine{}
+	g2GenAff.FromJacobian(&g2Gen)
+
+	point1Bytes := encodeG1Point(&g1GenAff)
+	point2Bytes := encodeG2Point(&g2GenAff)
+
+	inputBytes := make([]byte, 2*sizeOfAffinePoint)
+	copy(inputBytes[:sizeOfAffinePoint], point1Bytes[:])
+	copy(inputBytes[sizeOfAffinePoint:], point2Bytes[:])
+
+	// Create the expected output. They also need to be in Montgomery form as Bytes converts back into normal form.
+	expectedResult, err := bw6761.PairingCheck([]bw6761.G1Affine{g1GenAff}, []bw6761.G2Affine{g2GenAff})
+	var expectedResultWord byte
+	if expectedResult {
+		expectedResultWord = 1
+	} else {
+		expectedResultWord = 0
+	}
+	expectedBytes := []byte{expectedResultWord}
+
+	// Run the precompile
+	retData, err := (&bw6761PairingCheckPrecompile{}).Run(evm, inputBytes)
+	require.Nil(t, err)
+
+	// Check the returned value is correct
+	require.Equal(t, len(retData), len(expectedBytes))
+	require.Equal(t, retData, expectedBytes)
+}
+
+func TestDecodeFieldElementInto(t *testing.T) {
+	// Create our input
+	var input fp.Element
+	_, err1 := input.SetRandom()
+	require.NoErrorf(t, err1, "generating input failed")
+	inputBytes := input.Bytes()
+
+	// Test decoding
+	var element fp.Element
+	err2 := decodeFieldElementInto(inputBytes[:], &element)
+	require.NoErrorf(t, err2, "decoding failed")
+	require.Equal(t, element, input)
+}
+
+// TestDecodeEncodeG1Point ensures that we can decode and encode a G1 point correctly.
+func TestDecodeEncodeG1Point(t *testing.T) {
+	// Create our input
+	input := make([]byte, sizeOfAffinePoint)
+	var inputX, inputY fp.Element
+	_, err1 := inputX.SetRandom()
+	require.NoErrorf(t, err1, "generating input failed")
+	_, err2 := inputY.SetRandom()
+	require.NoErrorf(t, err2, "generating input failed")
+	xBytes := inputX.Bytes()
+	yBytes := inputY.Bytes()
+	copy(input[:sizeOfFieldElement], xBytes[:])
+	copy(input[sizeOfFieldElement:], yBytes[:])
+
+	// Test the decoding functionality
+	point, decodeErr := decodeG1Point(input)
+	require.NoErrorf(t, decodeErr, "decoding the point failed")
+	require.Equal(t, point.X, inputX)
+	require.Equal(t, point.Y, inputY)
+
+	// Test the encoding functionality
+	bytes := encodeG1Point(point)
+	require.Equal(t, bytes, input)
+}
+
+// TestDecodeEncodeG2Point ensures that we can decode and encode a G2 point correctly.
+func TestDecodeEncodeG2Point(t *testing.T) {
+	// Create our input
+	input := make([]byte, sizeOfAffinePoint)
+	var inputX, inputY fp.Element
+	_, err1 := inputX.SetRandom()
+	require.NoErrorf(t, err1, "generating input failed")
+	_, err2 := inputY.SetRandom()
+	require.NoErrorf(t, err2, "generating input failed")
+	xBytes := inputX.Bytes()
+	yBytes := inputY.Bytes()
+	copy(input[:sizeOfFieldElement], xBytes[:])
+	copy(input[sizeOfFieldElement:], yBytes[:])
+
+	// Test the decoding functionality
+	point, decodeErr := decodeG2Point(input)
+	require.NoErrorf(t, decodeErr, "decoding the point failed")
+	require.Equal(t, point.X, inputX)
+	require.Equal(t, point.Y, inputY)
+
+	// Test the encoding functionality
+	bytes := encodeG2Point(point)
+	require.Equal(t, bytes, input)
 }

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -143,6 +143,12 @@ const (
 	Bls12381MapG1Gas          uint64 = 5500   // Gas price for BLS12-381 mapping field element to G1 operation
 	Bls12381MapG2Gas          uint64 = 110000 // Gas price for BLS12-381 mapping field element to G2 operation
 
+	Bw6761G1AddGas   uint64 = 600   // Price for BW6-761 elliptic curve G1 point addition
+	Bw6761G1MulGas   uint64 = 12000 // Price for BW6-761 elliptic curve G1 point scalar multiplication
+	Bw6761G2AddGas   uint64 = 4500  // Price for BW6-761 elliptic curve G2 point addition
+	Bw6761G2MulGas   uint64 = 55000 // Price for BW6-761 elliptic curve G2 point scalar multiplication
+	Bw6761PairingGas uint64 = 23000 // Price for BW6-761 elliptic curve pairing check
+
 	QuorumMaximumExtraDataSize uint64 = 65 // Maximum size extra data may be after Genesis.
 	// Quorum - payload for a transaction, the size of the buffer to 128kb to match the maximum allowed in chain config
 	QuorumMaxPayloadBufferSize uint64 = 128


### PR DESCRIPTION
This PR includes working precompiles for:

- G1 point addition
- G2 point addition
- G1 scalar multiplication
- G2 scalar multiplication
- BW6-761 pairing checks

Note that the test coverage is very low at the moment, and only tests the happy paths. This is in aid of making things available before the break to avoid the potential for any blockers. More tests are to come.